### PR TITLE
Bugfix for utf-8 handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,8 @@ RUN mvn dependency:go-offline
 COPY NERScriber ${NERVE_NERSCRIBER_SRC} 
 
 # Run Maven to build the NERScriber jar
-RUN mvn clean install
+# RUN mvn clean install
+RUN mvn install
 
 # copy pom.xml and cache dependancies
 COPY Service/pom.xml ${NERVE_SERVICE_SRC}/pom.xml

--- a/NERScriber/src/main/java/ca/sharcnet/nerve/scriber/query/Query.java
+++ b/NERScriber/src/main/java/ca/sharcnet/nerve/scriber/query/Query.java
@@ -83,8 +83,14 @@ public class Query extends ArrayList<Node> {
         this.add(document.getDocumentElement());
     }
 
+    // TODO detect document type from input, currently hard coded to UTF-8
     public Query(String string) throws SAXException {
+        this(string, "UTF-8");
+    }
+
+    public Query(String string, String encoding) throws SAXException {
         try {
+            this.encoding = encoding;
             DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
             builder = dbf.newDocumentBuilder();
             InputStream inputStream = new ByteArrayInputStream(string.getBytes(Charset.forName("UTF-8")));

--- a/NERScriber/src/main/java/ca/sharcnet/nerve/scriber/query/QueryPrinter.java
+++ b/NERScriber/src/main/java/ca/sharcnet/nerve/scriber/query/QueryPrinter.java
@@ -1,7 +1,10 @@
 package ca.sharcnet.nerve.scriber.query;
+
+import static ca.sharcnet.nerve.scriber.Constants.LOG_NAME;
 import ca.sharcnet.nerve.scriber.query.Query;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.Charset;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 
@@ -10,6 +13,9 @@ import org.w3c.dom.Node;
  * @author edward
  */
 public class QueryPrinter {
+
+    final static org.apache.logging.log4j.Logger LOGGER = org.apache.logging.log4j.LogManager.getLogger(LOG_NAME);
+
     /**
      * Replace all instances of escapable characters with their escape sequence.
      *
@@ -53,10 +59,16 @@ public class QueryPrinter {
     public String toString() {
         StringBuilder sBuilder = new StringBuilder();
 
+        // Todo:refactor to allow other encodings and removal of OutputStream to simplify
         OutputStream os = new OutputStream() {
             @Override
             public void write(int b) throws IOException {
                 sBuilder.append((char) b);
+            }
+            @Override
+            public void write(byte[] b) throws IOException {
+                LOGGER.trace(new String(b, "UTF-8"));
+                sBuilder.append(new String(b, "UTF-8"));
             }
         };
 
@@ -104,6 +116,7 @@ public class QueryPrinter {
                 if (element.attributes().size() > 0) sBuilder.deleteCharAt(sBuilder.length() - 1);
 
                 sBuilder.append(">");
+                LOGGER.trace(sBuilder.toString());
                 outputStream.write(sBuilder.toString().getBytes());
 
                 for (Node child : element.children(n -> true)) {
@@ -112,6 +125,7 @@ public class QueryPrinter {
 
                 sBuilder = new StringBuilder();
                 sBuilder.append("</").append(element.tagName()).append(">");
+                LOGGER.trace(sBuilder.toString());
                 outputStream.write(sBuilder.toString().getBytes());
                 break;
 
@@ -123,6 +137,7 @@ public class QueryPrinter {
                 outputStream.write(sBuilder.toString().getBytes());
                 break;
             case Node.TEXT_NODE:
+                LOGGER.trace(escape(node.getTextContent()));
                 outputStream.write(escape(node.getTextContent()).getBytes());
                 break;
             case Node.COMMENT_NODE:

--- a/NERScriber/src/test/java/ca/sharcnet/nerve/scriber/integration/SimpleIntegrationTest.java
+++ b/NERScriber/src/test/java/ca/sharcnet/nerve/scriber/integration/SimpleIntegrationTest.java
@@ -94,5 +94,10 @@ public class SimpleIntegrationTest extends Integration {
 
         assertEquals(1, select.size());
         assertEquals("Toronto", select.text());
+
+        select = query.select("#4 > LOCATION");
+        assertEquals(1, select.size());                                                            
+        assertEquals("Montréal", select.text());                                                     
+        assertEquals("<LOCATION>Montréal</LOCATION>", select.toString()); // Test QueryPrinter toString method on non-ascii      
     }
 }

--- a/NERScriber/src/test/resources/xml/int/integration00.xml
+++ b/NERScriber/src/test/resources/xml/int/integration00.xml
@@ -1,9 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ROOT>
     <div id="1">
-        Toronto
+        Toronto 
     </div>
     <div id="2">
         <LOCATION>Toronto</LOCATION>
+    </div>
+    <div id="3">
+        Montreal 
+    </div>
+    <div id="4">
+        <LOCATION>Montréal</LOCATION>
     </div>
 </ROOT>

--- a/README.md
+++ b/README.md
@@ -89,10 +89,11 @@ curl -i -X POST -H "Content-Type: application/x-www-form-urlencoded" \
   -d @./test_documents/nerve_test_cwrc_tei_lite.json  http://localhost:6642/ner
 ```
 
-Input: Custom context file (default attributes, smae element name test)
+Input: Custom context file (default attributes (e.g., resp or type) and same element name test (e.g., rs with type attribute to record entities)
+```
 curl -i -X POST -H "Content-Type: application/x-www-form-urlencoded" \
   -d @./test_documents/nerve_test_cwrc_tei_lite_custom_context_rs.json  http://localhost:6642/ner
-
+```
 
 More details in the wiki API [section](https://github.com/cwrc/NERVE/wiki/Endpoint-Descriptions-(api))
 

--- a/Service/src/main/java/ca/sharcnet/nerve/scriber/service/EncoderNERService.java
+++ b/Service/src/main/java/ca/sharcnet/nerve/scriber/service/EncoderNERService.java
@@ -63,6 +63,7 @@ public class EncoderNERService extends HttpServlet {
 
         /* get all of the input as one string */
         String input = request.getReader().lines().collect(Collectors.joining());
+        LOGGER.trace(input);
 
         if (input == null || input.isEmpty()) {
             jsonResponse = this.badRequest("Missing JSON in message body.");

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -15,7 +15,7 @@ services:
     volumes:
       - ./container_volumes/tomcat_logs-dev/:/usr/local/tomcat/logs
     environment:
-      - LOG_LEVEL=VERBOSE # Log4J Logging level: WARN, VERBOSE
+      - LOG_LEVEL=VERBOSE # Log4J Logging level: TRACE, WARN, VERBOSE
     restart: unless-stopped
     stdin_open: true
     tty: true


### PR DESCRIPTION
Fixes utf-8 character handling

* addresses https://github.com/cwrc/CWRC-WriterBase/issues/234
* update QueryPrint toString with UTF-8 fix
* needs refactor to allow other charset
* add test for UTF-8 and QueryPrinter.toString() 